### PR TITLE
add missing jquery

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,6 +14,7 @@
 
   <!-- Load JavaScript files -->
   <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/toastr.min.js"></script>
 </head>
 


### PR DESCRIPTION
**Description**
Add missing jquery to fix toast message not showing.

**Reference**
![image](https://github.com/user-attachments/assets/1bb6241d-0e28-47e7-8c5e-27c12de59e7d)


<img width="1326" alt="Screenshot 2024-09-21 at 11 56 10 PM" src="https://github.com/user-attachments/assets/6751349e-2cd1-4b2f-a02a-c286dbfb9c41">
<img width="1326" alt="Screenshot 2024-09-22 at 12 10 59 AM" src="https://github.com/user-attachments/assets/8e494c32-d208-46db-aad5-ab0743039941">

